### PR TITLE
Fix launch on stock Macs, Xcode 27 build, and window clipping

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ project(JoyCon2Mac)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_OSX_DEPLOYMENT_TARGET "11.0")
+set(CMAKE_OSX_DEPLOYMENT_TARGET "13.0")
 
 # Require Xcode generator if we are building the driverkit extension
 if(NOT CMAKE_GENERATOR STREQUAL "Xcode")
@@ -50,7 +50,6 @@ if(CMAKE_GENERATOR STREQUAL "Xcode")
         XCODE_ATTRIBUTE_WRAPPER_EXTENSION "dext"
         XCODE_ATTRIBUTE_MACH_O_TYPE "mh_execute"
         XCODE_ATTRIBUTE_SDKROOT "driverkit"
-        XCODE_ATTRIBUTE_SYSTEM_HEADER_SEARCH_PATHS "$(inherited) $(SDKROOT)/System/DriverKit/usr/include"
         XCODE_ATTRIBUTE_USER_HEADER_SEARCH_PATHS "$(inherited) $(DERIVED_SOURCES_DIR)"
         XCODE_ATTRIBUTE_LIBRARY_SEARCH_PATHS "$(inherited) $(SDKROOT)/System/DriverKit/usr/lib"
         XCODE_ATTRIBUTE_GENERATE_INFOPLIST_FILE "YES"

--- a/JoyCon2MacApp/JoyCon2MacApp.swift
+++ b/JoyCon2MacApp/JoyCon2MacApp.swift
@@ -11,8 +11,8 @@ struct JoyCon2MacApp: App {
         WindowGroup {
             MainWindow()
                 .environmentObject(daemonBridge)
-                .frame(minWidth: 800, minHeight: 600)
         }
+        .windowResizability(.contentMinSize)
         .commands {
             CommandGroup(replacing: .newItem) {}
         }

--- a/README.md
+++ b/README.md
@@ -24,16 +24,48 @@ Do not treat this as a normal consumer install yet. Re-enable SIP/AMFI when you 
 
 ### Install From Release
 
-1. Download `JoyCon2Mac.app.zip` from the GitHub release.
-2. Unzip it.
-3. Move `JoyCon2Mac.app` to `/Applications`.
-4. Launch the app. If Gatekeeper blocks the first launch, right-click the app and choose `Open`.
-5. Approve the DriverKit extension in `System Settings -> Privacy & Security`.
-6. If macOS asks for a restart, restart.
-7. Open JoyCon2Mac again.
-8. Hold `SYNC` on each Joy-Con until the LEDs flash, then let the app connect.
+Existing releases were signed with the restricted system-extension entitlement, so on a stock Mac (SIP enabled) they do not launch at all — macOS reports `The application "JoyCon2Mac" can't be opened`. Right-click → `Open` does not help; the process is killed before Gatekeeper is even involved. Pick one of the two paths below.
 
-If the app opens but no controller or mouse appears in Chrome, SDL apps, or macOS, the system extension is probably not loaded or macOS blocked the unverified driver.
+#### Path A: app only, stock Mac (no driver — telemetry, battery, and gyro views work; gamepad and mouse do not)
+
+1. Download `JoyCon2Mac.app.zip` from the GitHub release and unzip it.
+2. Move `JoyCon2Mac.app` to `/Applications`.
+3. Strip the entitlement the release cannot use anyway:
+
+   ```bash
+   xattr -d com.apple.quarantine /Applications/JoyCon2Mac.app 2>/dev/null
+   codesign -s - -f /Applications/JoyCon2Mac.app
+   ```
+
+4. Launch the app.
+
+#### Path B: full functionality (driver development machine)
+
+The DriverKit extension is unsigned, so macOS will only load it with driver-development protections lowered. Do this only on a Mac you are comfortable using for driver development.
+
+1. Boot into Recovery (shut down, then hold the power button), open `Utilities -> Terminal`, and run:
+
+   ```bash
+   csrutil disable
+   nvram boot-args="amfi_get_out_of_my_way=1"
+   ```
+
+   Reboot back into macOS.
+2. Enable system-extension developer mode:
+
+   ```bash
+   systemextensionsctl developer on
+   ```
+
+3. Install `JoyCon2Mac.app` into `/Applications` (release zip as-is, or a local `FORCE_ENTITLEMENTS=1 ./build_all.sh` build).
+4. Launch the app and approve the DriverKit extension in `System Settings -> Privacy & Security`.
+5. If macOS asks for a restart, restart, then open JoyCon2Mac again.
+
+#### Pairing
+
+Hold `SYNC` on each Joy-Con until the LEDs flash, then let the app connect.
+
+If the app opens but no controller or mouse appears in Chrome, SDL apps, or macOS, the system extension is not loaded — check `systemextensionsctl list` and the Path B prerequisites.
 
 ### Build And Install Locally
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,24 @@ open build/JoyCon2Mac.app
 build/JoyCon2Mac.app/Contents/Library/SystemExtensions/
 ```
 
+Building requires full Xcode (the DriverKit SDK is not part of the Command Line Tools). If only a beta Xcode is installed, point the build at it:
+
+```bash
+DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer ./build_all.sh
+```
+
+### Signing Modes
+
+Without `CODE_SIGN_IDENTITY`, builds are ad-hoc signed **without** the restricted `com.apple.developer.system-extension.install` entitlement — macOS kills ad-hoc apps that carry it at launch ("The application \"JoyCon2Mac\" can't be opened"), which is also why older releases refused to start on stock Macs. Such builds launch anywhere, but cannot activate the DriverKit extension, so only telemetry works.
+
+To get the full driver on a SIP/AMFI-disabled development machine, keep the entitlement:
+
+```bash
+FORCE_ENTITLEMENTS=1 ./build_all.sh
+```
+
+With a real signing identity (`CODE_SIGN_IDENTITY=...`), entitlements are always embedded.
+
 ## What Works
 
 ### Gamepad

--- a/build_all.sh
+++ b/build_all.sh
@@ -32,9 +32,14 @@ embed_dext() {
     /bin/rm -rf "$SYSTEM_EXTENSIONS_DIR/VirtualJoyConDriver.dext"
     /bin/rm -rf "$SYSTEM_EXTENSIONS_DIR/$DEXT_NAME"
     cp -R "$source" "$SYSTEM_EXTENSIONS_DIR/$DEXT_NAME"
-    codesign -s "$SIGN_IDENTITY" -f --deep --generate-entitlement-der \
-        --entitlements "$ROOT_DIR/JoyCon2MacApp/JoyCon2Mac.entitlements" \
-        "$ROOT_DIR/build/JoyCon2Mac.app" >/dev/null
+    if [ "$SIGN_IDENTITY" = "-" ] && [ "${FORCE_ENTITLEMENTS:-0}" != "1" ]; then
+        codesign -s "$SIGN_IDENTITY" -f --deep \
+            "$ROOT_DIR/build/JoyCon2Mac.app" >/dev/null
+    else
+        codesign -s "$SIGN_IDENTITY" -f --deep --generate-entitlement-der \
+            --entitlements "$ROOT_DIR/JoyCon2MacApp/JoyCon2Mac.entitlements" \
+            "$ROOT_DIR/build/JoyCon2Mac.app" >/dev/null
+    fi
 }
 
 # If we already have a pre-built dext around, embed it immediately so

--- a/build_gui.sh
+++ b/build_gui.sh
@@ -85,6 +85,11 @@ swiftc \
     -o "$MACOS_DIR/JoyCon2Mac"
 
 codesign -s "$SIGN_IDENTITY" -f "$HELPER_APP" >/dev/null
-codesign -s "$SIGN_IDENTITY" -f --deep --generate-entitlement-der --entitlements "$APP_ENTITLEMENTS" "$APP_DIR" >/dev/null
+if [ "$SIGN_IDENTITY" = "-" ] && [ "${FORCE_ENTITLEMENTS:-0}" != "1" ]; then
+    echo "Ad-hoc signing: omitting restricted entitlements (set FORCE_ENTITLEMENTS=1 for SIP/AMFI-disabled dev machines)."
+    codesign -s "$SIGN_IDENTITY" -f --deep "$APP_DIR" >/dev/null
+else
+    codesign -s "$SIGN_IDENTITY" -f --deep --generate-entitlement-der --entitlements "$APP_ENTITLEMENTS" "$APP_DIR" >/dev/null
+fi
 
 echo "Built: $APP_DIR"


### PR DESCRIPTION
Thanks for the app! I ran into a few problems getting it to launch, and the guide doesn't fully describe the process. Since this isn't really my area, I gave fixing it a try with the help of AI. The changes are small, so there shouldn't be any issues. See for yourself whether you're comfortable with this, and if any additional changes are needed — happy to make them.

What's fixed:

- Launch failure on stock macOS (fixes #3 — approving the app in Privacy & Security doesn't help because the process is killed before Gatekeeper is involved). Releases were ad-hoc signed with the restricted com.apple.developer.system-extension.install entitlement. Without a provisioning profile, AMFI kills such a process at spawn, so users got The application "JoyCon2Mac" can't be opened (POSIX error 163). Ad-hoc builds now sign without the entitlement and launch anywhere; FORCE_ENTITLEMENTS=1 keeps it for SIP/AMFI-disabled dev machines, and real signing identities embed it as before.
- Xcode 27 build fixes. Deployment target 11.0 is below Xcode 27's supported minimum (12.0), which broke CMake's compiler probe ("No CMAKE_OBJCXX_COMPILER could be found") — raised to 13.0 to match the app's LSMinimumSystemVersion. The dext target also manually added $(SDKROOT)/System/DriverKit/usr/include to system header search paths, shadowing libc++'s headers, which Xcode 27's clang now rejects; SDKROOT=driverkit already sets the paths correctly.
- Window clipping. The WindowGroup root capped the window at 800×600 while MainWindow requires 960×640, so SwiftUI centered the oversized content and clipped it on every edge. Dropped the conflicting frame and added .windowResizability(.contentMinSize).
- README. Rewrote Install From Release to match reality (stock-Mac path without the driver vs. full dev-machine path) and documented the signing modes and beta-Xcode DEVELOPER_DIR builds.

Until a new release is cut, anyone hitting #3 can work around it on the current release with codesign -s - -f /Applications/JoyCon2Mac.app (details in the updated README).